### PR TITLE
base_pbp: add manual download formula

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,8 @@
 language: ruby
 os: osx
 osx_image: xcode8.2
+# Hack to work around a weird broken PR behaviour in `brew test-bot`
+before_script:
+  - mkdir -p $(brew --prefix)/Homebrew/Library/taps/ticky/homebrew-playstation
+  - ln -s . $(brew --prefix)/Homebrew/Library/taps/ticky/homebrew-playstation
 script: brew test-bot --ci-auto ./Formula/*.rb

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,5 @@ osx_image: xcode8.2
 before_script:
   - mkdir -p $(brew --prefix)/Homebrew/Library/taps/ticky
   - ln -s $(pwd) $(brew --prefix)/Homebrew/Library/taps/ticky/homebrew-playstation
-script: brew test-bot --ci-auto ./Formula/*.rb
+# Hack to avoid testing BASE.PBP and its dependencies in CI
+script: brew test-bot --ci-auto $(grep -Lwr --include=\*.rb ./Formula -e "BASE.PBP" -e "base_pbp")

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,5 @@ osx_image: xcode8.2
 # Hack to work around a weird broken PR behaviour in `brew test-bot`
 before_script:
   - mkdir -p $(brew --prefix)/Homebrew/Library/taps/ticky/homebrew-playstation
-  - ln -s . $(brew --prefix)/Homebrew/Library/taps/ticky/homebrew-playstation
+  - ln -s $(pwd) $(brew --prefix)/Homebrew/Library/taps/ticky/homebrew-playstation
 script: brew test-bot --ci-auto ./Formula/*.rb

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,6 @@ os: osx
 osx_image: xcode8.2
 # Hack to work around a weird broken PR behaviour in `brew test-bot`
 before_script:
-  - mkdir -p $(brew --prefix)/Homebrew/Library/taps/ticky/homebrew-playstation
+  - mkdir -p $(brew --prefix)/Homebrew/Library/taps/ticky
   - ln -s $(pwd) $(brew --prefix)/Homebrew/Library/taps/ticky/homebrew-playstation
 script: brew test-bot --ci-auto ./Formula/*.rb

--- a/Formula/base_pbp.rb
+++ b/Formula/base_pbp.rb
@@ -1,0 +1,25 @@
+class NullDownloadStrategy < CurlDownloadStrategy
+  def fetch
+    if !File.exist? @tarball_path
+      odie "You must manually download BASE.PBP and place it in: #{@tarball_path}"
+    else
+      super
+    end
+  end
+end
+
+class BasePbp < Formula
+  desc "Base Popstation executable image"
+  homepage "https://dontlook.here"
+  url "BASE.PBP", :using => NullDownloadStrategy
+  version "1.0"
+  sha256 "e0d49b137102eea2d50a9cfc8359e9cd835d10c3f657b59fc0f086b4671cec3d"
+
+  def install
+    pkgshare.install "BASE.PBP"
+  end
+
+  test do
+    File.exist? "#{pkgshare}/BASE.PBP"
+  end
+end

--- a/Formula/popstation.rb
+++ b/Formula/popstation.rb
@@ -6,9 +6,11 @@ class Popstation < Formula
 
   head "https://github.com/ticky/popstation.git"
 
+  depends_on "base_pbp"
   depends_on "iniparser"
 
   def install
+    inreplace "common.h", "BASE.PBP", Formula["base_pbp"].opt_pkgshare/"BASE.PBP"
     system "make"
     bin.install "popstation", "popstation_md"
   end

--- a/Formula/popstation.rb
+++ b/Formula/popstation.rb
@@ -2,7 +2,7 @@ class Popstation < Formula
   desc "Utility to convert PlayStation ISOs for use with PSP Popstation"
   homepage "https://github.com/ticky/popstation"
   url "https://github.com/ticky/popstation.git", :revision => "51365d05c757ee346f8f1c4b9ea2691a2b8be608"
-  version "2017-03-19T07:24:14Z"
+  version "2017-03-25T11:25:43Z"
 
   head "https://github.com/ticky/popstation.git"
 


### PR DESCRIPTION
If the user hasn't already manually downloaded it, it will fail like this:

```
=> Installing base_pbp from ticky/playstation
Error: You must manually download BASE.PBP and place it in: ~/Library/Caches/Homebrew/base_pbp-1.0.PBP
```

Otherwise it works as expected:

```
==> Fetching base_pbp from ticky/playstation
==> Downloading BASE.PBP
Already downloaded: ~/Library/Caches/Homebrew/base_pbp-1.0.PBP
SHA256: e0d49b137102eea2d50a9cfc8359e9cd835d10c3f657b59fc0f086b4671cec3d
```