### PR TITLE
quickbms 0.8.1

### DIFF
--- a/Formula/quickbms.rb
+++ b/Formula/quickbms.rb
@@ -2,26 +2,18 @@ class Quickbms < Formula
   desc "Generic file extractor and reimporter"
   homepage "http://aluigi.altervista.org/quickbms.htm"
   url "http://aluigi.altervista.org/papers/quickbms_src.zip"
-  version "0.8.0"
-  sha256 "b2dc34503f0371fbc796efa270ce38a0c8dd0d1a8960d6c23f793bdf2abdc596"
-
-  depends_on "openssl"
+  version "0.8.1"
+  sha256 "90d003347c31b7ef02422703e3a3f76d0283d475f162d756729b0c488e3fc4d5"
 
   fails_with :clang
   fails_with :gcc_4_0
   fails_with :gcc_4_2
 
-  # Bundles various OS X-specific fixes and improvements
-  patch do
-    url "https://github.com/mistydemeo/quickbms/compare/v0.8.0...5752a6a2a38e16211952553fcffa59570855ac42.patch"
-    sha256 "be8d91d08358a76366101dc1cf7c2fcecab5e0cf70bddb227b3c2263dc54c131"
-  end
-
   def install
     # quickbms is 32-bit only
     ENV.m32
 
-    system "make", "USE_OPENSSL=1"
+    system "make"
     system "make", "install", "PREFIX=#{prefix}"
   end
 


### PR DESCRIPTION
This release incorporates my patches, so I've dropped the patch block. Also dropped openssl support for now, since Homebrew's bottle no longer ships a 32-bit slice.