### PR TITLE
usbhostfs_pc: needs libusb-compat

### DIFF
--- a/Formula/usbhostfs_pc.rb
+++ b/Formula/usbhostfs_pc.rb
@@ -6,6 +6,8 @@ class UsbhostfsPc < Formula
 
   head "https://github.com/pspdev/psplinkusb.git"
 
+  depends_on "libusb-compat"
+
   def install
     cd "usbhostfs_pc" do
       system "make"


### PR DESCRIPTION
Noticed the build was failing because it couldn't find `usb.h`. I think it was opportunistically picking it up on the system, which is why it would build locally if it was already there but not in CI.