### PR TITLE
base_pbp: fix for newer Homebrew

### DIFF
--- a/Formula/base_pbp.rb
+++ b/Formula/base_pbp.rb
@@ -1,9 +1,9 @@
 class NullDownloadStrategy < CurlDownloadStrategy
   def fetch
-    if File.exist? @tarball_path
+    if File.exist? cached_location
       super
     else
-      odie "You must manually download BASE.PBP and place it in: #{@tarball_path}"
+      odie "You must manually download BASE.PBP and place it in: #{cached_location}"
     end
   end
 end


### PR DESCRIPTION
The `@tarball_path` instance variable was renamed to something a bit more general.